### PR TITLE
fix: Remove trailing period from workflow name in SonarCloud analysis

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -1,4 +1,4 @@
-name: SonarCloud Analysis - Campus Map.
+name: SonarCloud Analysis - Campus Map
 
 on:
   push:


### PR DESCRIPTION
This pull request makes a minor change to the `.github/workflows/sonarcloud-analysis.yml` file, removing a trailing period from the workflow name for consistency.