### PR TITLE
feat(places): add endpoints to get all places and places by type

### DIFF
--- a/campusmap-server/.env.example
+++ b/campusmap-server/.env.example
@@ -17,3 +17,6 @@ DB_LOGGING=false
 DB_SSL=false
 # Require trusted certificates when SSL is enabled
 DB_SSL_REJECT_UNAUTHORIZED=false
+
+# List of allowed CORS origins, separated by commas
+CORS_ALLOW=http://localhost:3000,http://localhost:4200

--- a/campusmap-server/.vscode/settings.json
+++ b/campusmap-server/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "material-icon-theme.activeIconPack": "nest"
+}

--- a/campusmap-server/package-lock.json
+++ b/campusmap-server/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.0.2",
         "@nestjs/typeorm": "^11.0.0",
+        "@types/geojson": "^7946.0.16",
         "@vendia/serverless-express": "^4.10.2",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
@@ -3387,6 +3388,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/campusmap-server/package.json
+++ b/campusmap-server/package.json
@@ -26,10 +26,11 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.0.2",
     "@nestjs/typeorm": "^11.0.0",
+    "@types/geojson": "^7946.0.16",
+    "@vendia/serverless-express": "^4.10.2",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-  "@vendia/serverless-express": "^4.10.2",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.26"
   },
@@ -41,6 +42,7 @@
     "@nestjs/testing": "^11.0.1",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
+    "@types/aws-lambda": "^8.10.119",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
@@ -56,7 +58,6 @@
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
-    "@types/aws-lambda": "^8.10.119",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"

--- a/campusmap-server/src/api/api.module.ts
+++ b/campusmap-server/src/api/api.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ApiController } from './api.controller';
+import { PlacesModule } from 'src/modules/places/places.module';
 
 @Module({
+  imports: [PlacesModule], 
   controllers: [ApiController],
 })
 export class ApiModule {}

--- a/campusmap-server/src/app.module.ts
+++ b/campusmap-server/src/app.module.ts
@@ -9,6 +9,7 @@ import { routes } from './main.routes';
 import { RequestLoggerMiddleware } from './common/middleware/request-logger.middleware';
 import { AppLoggerService } from './common/logger/app-logger.service';
 import { buildTypeOrmOptions } from './database/typeorm.config';
+import { PlacesModule } from './modules/places/places.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { buildTypeOrmOptions } from './database/typeorm.config';
     }),
     ApiModule,
     RouterModule.register(routes),
+    PlacesModule,
   ],
   controllers: [AppController],
   providers: [AppService, AppLoggerService],

--- a/campusmap-server/src/common/dto/geojson.dto.ts
+++ b/campusmap-server/src/common/dto/geojson.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export type GeoJsonGeometryType = 
+  | 'Point' 
+  | 'LineString' 
+  | 'Polygon' 
+  | 'MultiPoint' 
+  | 'MultiLineString' 
+  | 'MultiPolygon';
+
+export type GeoJsonCoordinates = 
+  | number[]                    // Point: [lng, lat]
+  | number[][]                  // LineString o MultiPoint
+  | number[][][]                // Polygon o MultiLineString
+  | number[][][][];             // MultiPolygon
+
+export class GeometryDto {
+  @ApiProperty({ 
+    example: 'Point',
+    enum: ['Point', 'Polygon', 'LineString', 'MultiPoint', 'MultiPolygon', 'MultiLineString']
+  })
+  type: GeoJsonGeometryType;
+
+  @ApiProperty({ 
+    example: [[-75.5812, 6.2476], [-75.5815, 6.2478]],
+    description: 'Coordenadas en formato [longitude, latitude]'
+  })
+  coordinates: GeoJsonCoordinates;
+}
+
+export class FeatureDto<T = any> {
+  @ApiProperty({ example: 'Feature' })
+  type: 'Feature' = 'Feature';
+
+  @ApiProperty({ type: () => GeometryDto })
+  geometry: GeometryDto;
+
+  @ApiProperty()
+  properties: T;
+
+  @ApiProperty({ example: 1, required: false })
+  id?: number | string;
+}
+
+export class FeatureCollectionDto<T = any> {
+  @ApiProperty({ example: 'FeatureCollection' })
+  type: 'FeatureCollection' = 'FeatureCollection';
+  @ApiProperty({ example: 'Places' })
+  name: string;
+  @ApiProperty({ type: [FeatureDto], isArray: true })
+  features: FeatureDto<T>[];
+}

--- a/campusmap-server/src/main.ts
+++ b/campusmap-server/src/main.ts
@@ -13,8 +13,8 @@ async function bootstrap() {
   const adapterHost = app.get(HttpAdapterHost);
   app.useGlobalFilters(new AllExceptionsFilter(adapterHost, appLogger));
 
-   app.setGlobalPrefix('api/v1');
-   
+  app.setGlobalPrefix('api/v1');
+  app.enableCors();
   const config = new DocumentBuilder()
     .setTitle('CampusMap Server')
     .setDescription('API de CampusMap')

--- a/campusmap-server/src/main.ts
+++ b/campusmap-server/src/main.ts
@@ -9,12 +9,31 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const appLogger = await app.resolve(AppLoggerService);
   app.useLogger(appLogger);
-
   const adapterHost = app.get(HttpAdapterHost);
   app.useGlobalFilters(new AllExceptionsFilter(adapterHost, appLogger));
-
   app.setGlobalPrefix('api/v1');
-  app.enableCors();
+  
+  if (!process.env.CORS_ALLOW) {
+    appLogger.error('Error: La variable de entorno CORS_ALLOW no está definida');
+    process.exit(1);
+  }
+  
+  const corsOrigins = process.env.CORS_ALLOW.split(',').map(origin => origin.trim()).filter(origin => origin.length > 0);
+  
+  if (corsOrigins.length === 0) {
+    appLogger.error('Error: La variable CORS_ALLOW está vacía o no contiene orígenes válidos');
+    process.exit(1);
+  }
+  
+  app.enableCors({
+    origin: corsOrigins,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    credentials: true,
+    allowedHeaders: ['Content-Type', 'Authorization', 'Accept'],
+  });
+  
+  appLogger.log(`CORS habilitado para los orígenes: ${corsOrigins.join(', ')}`);
+  
   const config = new DocumentBuilder()
     .setTitle('CampusMap Server')
     .setDescription('API de CampusMap')
@@ -24,10 +43,10 @@ async function bootstrap() {
   SwaggerModule.setup('api/docs', app, document, {
     swaggerOptions: { persistAuthorization: true },
   });
-
   const port = Number(process.env.PORT ?? 3000);
   await app.listen(port);
   appLogger.log(`Servidor escuchando en http://localhost:${port}`);
   appLogger.log(`Documentación API en http://localhost:${port}/api/docs`);
+  appLogger.log(`CORS habilitado para: ${corsOrigins.join(', ')}`);
 }
 void bootstrap();

--- a/campusmap-server/src/main.ts
+++ b/campusmap-server/src/main.ts
@@ -13,6 +13,8 @@ async function bootstrap() {
   const adapterHost = app.get(HttpAdapterHost);
   app.useGlobalFilters(new AllExceptionsFilter(adapterHost, appLogger));
 
+   app.setGlobalPrefix('api/v1');
+   
   const config = new DocumentBuilder()
     .setTitle('CampusMap Server')
     .setDescription('API de CampusMap')

--- a/campusmap-server/src/modules/places/dtos/places.dto.ts
+++ b/campusmap-server/src/modules/places/dtos/places.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GeometryDto } from '../../../common/dto/geojson.dto';
+
+export class PlacePropertiesDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'Edificio Principal' })
+  name: string;
+
+  @ApiProperty({ example: 1, required: false })
+  groupId?: number;
+
+  @ApiProperty({ example: 1, required: false })
+  typeId?: number;
+
+  @ApiProperty({ example: 'https://...', required: false })
+  imageUrl?: string;
+
+  @ApiProperty({ type: () => GeometryDto, description: 'Centroid del lugar' })
+  centroid: GeometryDto;
+}
+
+export class PlaceFeatureDto {
+  @ApiProperty({ example: 'Feature' })
+  type: 'Feature' = 'Feature';
+
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ type: () => GeometryDto, description: 'Área del lugar (Polygon)' })
+  geometry: GeometryDto;
+
+  @ApiProperty({ type: () => PlacePropertiesDto })
+  properties: PlacePropertiesDto;
+}

--- a/campusmap-server/src/modules/places/entities/group-place.entity.ts
+++ b/campusmap-server/src/modules/places/entities/group-place.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Place } from './place.entity';
+
+@Entity({ name: 'group_places', schema: 'campus_map' })
+export class GroupPlace {
+  @PrimaryGeneratedColumn({
+    type: 'integer',
+    name: 'id',
+  })
+  id: number;
+
+  @Column({
+    type: 'varchar',
+    length: 50,
+    nullable: false,
+    unique: true,
+  })
+  code: string;
+
+  @OneToMany(() => Place, (place) => place.group)
+  places: Place[];
+}

--- a/campusmap-server/src/modules/places/entities/place.entity.ts
+++ b/campusmap-server/src/modules/places/entities/place.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Geometry } from 'geojson';
+import { GroupPlace } from './group-place.entity';
+import { TypePlace } from './type-place.entity';
+
+@Entity({ name: 'place', schema: 'campus_map' })
+export class Place {
+  @PrimaryGeneratedColumn({
+    type: 'integer',
+    name: 'id',
+  })
+  id: number;
+
+  @Column({
+    type: 'varchar',
+    length: 255,
+    nullable: false,
+  })
+  name: string;
+
+  @Column({
+    type: 'geometry',
+    spatialFeatureType: 'Polygon',
+    srid: 4326,
+    nullable: false,
+  })
+  area: Geometry;
+
+  @Column({
+    type: 'geometry',
+    spatialFeatureType: 'Point',
+    srid: 4326,
+    nullable: false,
+  })
+  centroid: Geometry;
+
+  @Column({
+    type: 'integer',
+    name: 'group_id',
+    nullable: true,
+  })
+  groupId: number;
+
+  @Column({
+    type: 'integer',
+    name: 'type_id',
+    nullable: true,
+  })
+  typeId: number;
+
+  @Column({
+    type: 'text',
+    name: 'image_url',
+    nullable: true,
+  })
+  imageUrl: string;
+
+  @ManyToOne(() => GroupPlace, { nullable: true })
+  @JoinColumn({ name: 'group_id' })
+  group: GroupPlace;
+
+  @ManyToOne(() => TypePlace, { nullable: true })
+  @JoinColumn({ name: 'type_id' })
+  type: TypePlace;
+}

--- a/campusmap-server/src/modules/places/entities/type-place.entity.ts
+++ b/campusmap-server/src/modules/places/entities/type-place.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Place } from './place.entity';
+
+@Entity({ name: 'type_place', schema: 'campus_map' })
+export class TypePlace {
+  @PrimaryGeneratedColumn({
+    type: 'integer',
+    name: 'id',
+  })
+  id: number;
+
+  @Column({
+    type: 'varchar',
+    length: 50,
+    nullable: false,
+    unique: true,
+  })
+  code: string;
+
+  @OneToMany(() => Place, (place) => place.type)
+  places: Place[];
+}

--- a/campusmap-server/src/modules/places/mappers/places.mapper.ts
+++ b/campusmap-server/src/modules/places/mappers/places.mapper.ts
@@ -1,0 +1,39 @@
+import { Place } from '../entities/place.entity';
+import { PlacePropertiesDto } from '../dtos/places.dto';
+import { GeometryDto, FeatureDto, FeatureCollectionDto } from '../../../common/dto/geojson.dto';
+import { Point, Polygon, MultiPolygon } from 'geojson';
+
+type SupportedGeometry = Point | Polygon | MultiPolygon;
+
+export class PlacesMapper {
+  static toFeature(place: Place): FeatureDto<PlacePropertiesDto> {
+    return {
+      type: 'Feature',
+      id: place.id,
+      geometry: this.geometryToDto(place.area as SupportedGeometry),
+      properties: {
+        id: place.id,
+        name: place.name,
+        groupId: place.groupId,
+        typeId: place.typeId,
+        imageUrl: place.imageUrl,
+        centroid: this.geometryToDto(place.centroid as SupportedGeometry),
+      },
+    };
+  }
+
+  private static geometryToDto(geometry: SupportedGeometry): GeometryDto {
+    return {
+      type: geometry.type,
+      coordinates: geometry.coordinates,
+    };
+  }
+
+  static toFeatureCollection(places: Place[], name: string): FeatureCollectionDto<PlacePropertiesDto> {
+    return {
+      type: 'FeatureCollection',
+      name,
+      features: places.map(place => this.toFeature(place)),
+    };
+  }
+}

--- a/campusmap-server/src/modules/places/places.controller.spec.ts
+++ b/campusmap-server/src/modules/places/places.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlacesController } from './places.controller';
+
+describe('PlacesController', () => {
+  let controller: PlacesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PlacesController],
+    }).compile();
+
+    controller = module.get<PlacesController>(PlacesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/campusmap-server/src/modules/places/places.controller.ts
+++ b/campusmap-server/src/modules/places/places.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { PlacesService } from './places.service';
+import { FeatureCollectionDto } from '../../common/dto/geojson.dto';
+import { PlacePropertiesDto } from './dtos/places.dto';
+
+@ApiTags('places')
+@Controller('places')
+export class PlacesController {
+  constructor(private readonly placesService: PlacesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Obtener todos los lugares' })
+  @ApiOkResponse({ 
+    type: FeatureCollectionDto,
+    description: 'Lista de lugares en formato GeoJSON'
+  })
+  getAllPlaces(): Promise<FeatureCollectionDto<PlacePropertiesDto>> {
+    return this.placesService.getAllPlaces();
+  }
+
+  @Get('type/:code')
+  @ApiOperation({ summary: 'Obtener lugares por tipo' })
+  @ApiParam({
+    name: 'code',
+    type: String,
+    description: 'Código del tipo de lugar (por ejemplo: "building", "parking")',
+    example: 'building'
+  })
+  @ApiOkResponse({ 
+    type: FeatureCollectionDto,
+    description: 'Lugares filtrados por tipo en formato GeoJSON'
+  })
+  getPlacesByType(@Param('code') code: string): Promise<FeatureCollectionDto<PlacePropertiesDto>> {
+    return this.placesService.getPlacesByTypeCode(code);
+  }
+}

--- a/campusmap-server/src/modules/places/places.module.ts
+++ b/campusmap-server/src/modules/places/places.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PlacesController } from './places.controller';
+import { PlacesService } from './places.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Place } from './entities/place.entity';
+import { TypePlace } from './entities/type-place.entity';
+import { GroupPlace } from './entities/group-place.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Place, GroupPlace, TypePlace])],
+  controllers: [PlacesController],
+  providers: [PlacesService],
+})
+export class PlacesModule {}

--- a/campusmap-server/src/modules/places/places.service.spec.ts
+++ b/campusmap-server/src/modules/places/places.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlacesService } from './places.service';
+
+describe('PlacesService', () => {
+  let service: PlacesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PlacesService],
+    }).compile();
+
+    service = module.get<PlacesService>(PlacesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/campusmap-server/src/modules/places/places.service.ts
+++ b/campusmap-server/src/modules/places/places.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Place } from './entities/place.entity';
+import { PlacesMapper } from './mappers/places.mapper';
+import { FeatureCollectionDto } from '../../common/dto/geojson.dto';
+import { PlacePropertiesDto } from './dtos/places.dto';
+
+@Injectable()
+export class PlacesService {
+  constructor(
+    @InjectRepository(Place)
+    private readonly placeRepository: Repository<Place>,
+  ) {}
+
+  async getAllPlaces(): Promise<FeatureCollectionDto<PlacePropertiesDto>> {
+    const places = await this.placeRepository.find();
+    return PlacesMapper.toFeatureCollection(places, 'All Places');
+  }
+
+  async getPlacesByTypeCode(code: string): Promise<FeatureCollectionDto<PlacePropertiesDto>> {
+    const places = await this.placeRepository.find({
+      where: { type: { code } },
+    });
+    return PlacesMapper.toFeatureCollection(places, `Places of type ${code}`);
+  }
+}


### PR DESCRIPTION
This feature adds new API endpoints to retrieve place data.

GET /places — Returns a list of all available places.

GET /places/type/:type — Returns places filtered by their type (e.g., buildings, cafeterias, classrooms, etc.).

These endpoints will be used to display categorized place information on the frontend and improve user navigation across the campus map.