### PR TITLE
Add place model and integrate place selection on map

### DIFF
--- a/campusmap-client/src/app/core/models/place.model.ts
+++ b/campusmap-client/src/app/core/models/place.model.ts
@@ -1,0 +1,29 @@
+// Interface that defines the geometry (point, line, or polygon)
+export interface Geometry {
+  type: string;
+  coordinates: number[] | number[][] | number[][][];
+}
+
+// Extra data that describes a place
+export interface PlaceProperties {
+  id: number;
+  name: string;
+  groupId?: number;
+  typeId?: number;
+  imageUrl?: string;
+  centroid: Geometry;
+}
+
+// Represents a single geographic feature with geometry and properties
+export interface PlaceFeature {
+  type: 'Feature';
+  id: number;
+  geometry: Geometry;
+  properties: PlaceProperties;
+}
+
+// A collection that groups multiple features together
+export interface FeatureCollection {
+  type: 'FeatureCollection';
+  features: PlaceFeature[];
+}

--- a/campusmap-client/src/app/core/service/api.ts
+++ b/campusmap-client/src/app/core/service/api.ts
@@ -1,17 +1,29 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { FeatureCollection } from '../models/place.model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class Api {
-  private apiUrl =
-    'https://api.maptiler.com/data/019a17ce-d24d-7595-91de-c9e012d10b2d/features.json?key=ysbhdSG63XiCe6Sgq0TG';
-
+  private apiUrl = environment.apiUrl;
+  
   private http = inject(HttpClient);
 
-  getBuildings(): Observable<unknown> {
-    return this.http.get<unknown>(this.apiUrl);
+  //Gets all buildings in GeoJSON format
+  getBuildings(): Observable<FeatureCollection> {
+    return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/places`);
+  }
+
+  //Gets all places in GeoJSON format
+  getAllPlaces(): Observable<FeatureCollection> {
+    return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/places`);
+  }
+
+  //Gets places filtered by type example: 'building', 'parking'
+  getPlacesByType(typeCode: string): Observable<FeatureCollection> {
+    return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/places/type/${typeCode}`);
   }
 }

--- a/campusmap-client/src/app/modules/map/pages/map/components/information-pop-up/information-pop-up.html
+++ b/campusmap-client/src/app/modules/map/pages/map/components/information-pop-up/information-pop-up.html
@@ -1,15 +1,24 @@
 <!-- Bottom container showing detailed information of the selected site -->
 <div
+  *ngIf="isVisible"
   class="absolute bottom-0 left-0 w-screen lg:w-1/4 h-75 lg:h-screen md:h-110 px-4 md:px-8 lg:pt-12 pt-4 bg-white rounded-t-lg z-3">
   <div class="flex flex-col h-full">
+    <!-- Close button -->
+    <button
+      (click)="close()"
+      class="absolute top-4 right-4 w-8 h-8 flex items-center justify-center text-gray-600 hover:text-gray-900 text-2xl font-bold"
+      aria-label="Close">
+      &times;
+    </button>
+
     <!-- Point of interest titles -->
     <div class="flex flex-col pb-4 md:pb-8 lg:text-center">
       <p class="font-semibold text-(length:--font-size-2xl) md:text-(length:--font-size-4xl)">
-        Semillas del Futuro
+        {{ placeName || 'Sin nombre' }}
       </p>
       <p
         class="text-(length:--font-size-xl) leading-(length:--line-height-xl) md:text-(length:--font-size-3xl) md:leading-(length:--line-height-3xl) text-gray-600">
-        {{ 'InformationPopUp.building' | translate }}
+        {{ placeType || ('InformationPopUp.building' | translate) }}
       </p>
     </div>
 
@@ -17,25 +26,32 @@
     <div
       class="flex flex-auto lg:flex-col w-full h-40 lg:h-full justify-center lg:items-center gap-4 md:gap-8 px-2 md:px-4">
       <img
+        *ngIf="imageUrl"
+        [src]="imageUrl"
+        [attr.alt]="placeName"
+        class="w-full lg:w-full h-full rounded-lg object-cover" />
+      <img
+        *ngIf="!imageUrl"
         src="assets/images/rs.webp"
         [attr.alt]="'InformationPopUp.Alt' | translate"
         class="w-1/2 lg:w-full h-full rounded-lg object-cover" />
       <img
+        *ngIf="!imageUrl"
         src="assets/images/sostenibilidad.webp"
         [attr.alt]="'InformationPopUp.Alt' | translate"
         class="w-1/2 lg:w-full h-full rounded-lg object-cover" />
     </div>
 
-    <!-- Button to open the view of how to get there -->
+    <!-- Button to open transport button selector -->
     <div class="flex h-full justify-center items-center">
-      <a
-        routerLink="/map"
+      <button
+        (click)="openTransportSelector()"
         pButton
         class="flex justify-center items-center w-80px h-10 md:w-60 md:h-15 shadow-[4px_4px_5px_rgba(0,0,0,0.3)] text-center rounded-lg">
         <span pButtonLabel class="font-medium text-white text-center">
           {{ 'InformationPopUp.howToGet' | translate }}
         </span>
-      </a>
+      </button>
     </div>
   </div>
 </div>

--- a/campusmap-client/src/app/modules/map/pages/map/components/information-pop-up/information-pop-up.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/information-pop-up/information-pop-up.ts
@@ -1,12 +1,29 @@
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-information-pop-up',
-  imports: [RouterLink, ButtonModule, TranslateModule],
+  imports: [CommonModule, ButtonModule, TranslateModule],
   templateUrl: './information-pop-up.html',
   styleUrls: ['./information-pop-up.scss']
 })
-export class InformationPopUp {}
+export class InformationPopUp {
+  @Input() placeName = '';
+  @Input() placeType = '';
+  @Input() imageUrl = '';
+  @Input() isVisible = false;
+  @Output() visibleChange = new EventEmitter<boolean>();
+  @Output() showTransportSelector = new EventEmitter<void>();
+
+  close(): void {
+    this.isVisible = false;
+    this.visibleChange.emit(false);
+  }
+
+  openTransportSelector(): void {
+    this.close();
+    this.showTransportSelector.emit();
+  }
+}

--- a/campusmap-client/src/app/modules/map/pages/map/components/map-load/map-load.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/map-load/map-load.ts
@@ -1,6 +1,7 @@
-import { AfterViewInit, Component, OnDestroy, ElementRef, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, ElementRef, ViewChild, inject, Output, EventEmitter } from '@angular/core';
 import maplibregl from 'maplibre-gl';
 import { Api } from '../../../../../../core/service/api';
+import { PlaceFeature, FeatureCollection } from '../../../../../../core/models/place.model';
 
 @Component({
   selector: 'app-map-load',
@@ -10,6 +11,11 @@ import { Api } from '../../../../../../core/service/api';
   styleUrls: ['./map-load.scss']
 })
 export class MapLoad implements AfterViewInit, OnDestroy {
+  //Output event when a place is selected
+  @Output() placeSelected = new EventEmitter<{ name: string; type: string; imageUrl: string }>();
+  //Output event when the map is clicked
+  @Output() mapClicked = new EventEmitter<void>();
+
   //Map instances and controls
   private map!: maplibregl.Map;
   private geolocate!: maplibregl.GeolocateControl;
@@ -43,6 +49,12 @@ export class MapLoad implements AfterViewInit, OnDestroy {
     //Wait for the map to load to begin user tracking
     this.map.on('load', () => {
       this.trackUser();
+      this.loadPlaces();
+    });
+
+    //Emit event when map is clicked
+    this.map.on('click', () => {
+      this.mapClicked.emit();
     });
   }
 
@@ -142,6 +154,66 @@ export class MapLoad implements AfterViewInit, OnDestroy {
       const heading = e.alpha ?? 0;
       const el = this.userMarker.getElement();
       el.style.transform = `rotate(${heading}deg)`;
+    });
+  }
+
+  //Load places from API and display centroids on map
+  private loadPlaces(): void {
+
+    this.api.getAllPlaces().subscribe({
+      next: (data: FeatureCollection) => {
+        
+        if (data?.features && Array.isArray(data.features)) {
+          this.addCentroidsToMap(data.features);
+        } else {
+          console.warn('No hay features en los datos recibidos');
+        }
+      },
+      error: (error) => {
+        console.error('Error loading places:', error);
+      }
+    });
+  }
+
+  //Add centroid markers to the map
+  private addCentroidsToMap(features: PlaceFeature[]): void {
+    
+    features.forEach((feature: PlaceFeature, index: number) => {
+      const properties = feature.properties;
+      const centroid = properties?.centroid;
+
+      if (centroid?.coordinates && Array.isArray(centroid.coordinates)) {
+        const [lng, lat] = centroid.coordinates as number[];
+
+        // Create a custom marker element
+        const markerEl = document.createElement('div');
+        markerEl.style.width = '30px';
+        markerEl.style.height = '30px';
+        markerEl.style.backgroundColor = 'red'; // Color de respaldo visible
+        markerEl.style.borderRadius = '50%';
+        markerEl.style.border = '3px solid white';
+        markerEl.style.boxShadow = '0 2px 4px rgba(0,0,0,0.3)';
+        markerEl.style.backgroundImage = 'url(assets/icons/mapPage/bath.svg)';
+        markerEl.style.backgroundSize = 'cover';
+        markerEl.style.cursor = 'pointer';
+
+        // Add click event to marker
+        markerEl.addEventListener('click', (e) => {
+          e.stopPropagation(); // Prevent map click event
+          this.placeSelected.emit({
+            name: properties.name,
+            type: 'Building', // Puedes obtener esto de properties.typeId si lo tienes
+            imageUrl: properties.imageUrl || ''
+          });
+        });
+
+        // Add marker to map
+        new maplibregl.Marker({ element: markerEl })
+          .setLngLat([lng, lat])
+          .addTo(this.map);
+      } else {
+        console.warn(`Feature ${index + 1} no tiene coordenadas válidas de centroid`);
+      }
     });
   }
 

--- a/campusmap-client/src/app/modules/map/pages/map/components/map-load/map-load.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/map-load/map-load.ts
@@ -18,12 +18,12 @@ export class MapLoad implements AfterViewInit, OnDestroy {
 
   //Map instances and controls
   private map!: maplibregl.Map;
-  private geolocate!: maplibregl.GeolocateControl;
+  private readonly geolocate!: maplibregl.GeolocateControl;
   private userMarker!: maplibregl.Marker;
 
   //Reference to the map container in the template
   @ViewChild('mapContainer', { static: true })
-  private mapContainer!: ElementRef<HTMLDivElement>;
+  private readonly mapContainer!: ElementRef<HTMLDivElement>;
 
   //Service for future requests to the backend
   private readonly api = inject(Api);
@@ -68,7 +68,10 @@ export class MapLoad implements AfterViewInit, OnDestroy {
         const lat = pos.coords.latitude;
 
         //If the marker does not exist, create it with the visual elements
-        if (!this.userMarker) {
+        if (this.userMarker) {
+          //Updates user position
+          this.userMarker.setLngLat([lng, lat]);
+        } else {
           // Create user marker
           const elContainer = document.createElement('div');
           elContainer.style.position = 'absolute';
@@ -109,9 +112,6 @@ export class MapLoad implements AfterViewInit, OnDestroy {
             .addTo(this.map);
 
           this.requestOrientationPermission();
-        } else {
-          //Updates user position
-          this.userMarker.setLngLat([lng, lat]);
         }
       },
       err => console.error(err),
@@ -119,7 +119,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
     );
 
     // Orbit control to follow user
-    window.addEventListener('deviceorientation', e => {
+    globalThis.addEventListener('deviceorientation', e => {
       if (!this.userMarker) return;
       const heading = e.alpha ?? 0;
       const el = this.userMarker.getElement();
@@ -149,7 +149,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
 
   //Enable the device targeting event
   private enableDeviceOrientation() {
-    window.addEventListener('deviceorientation', e => {
+    globalThis.addEventListener('deviceorientation', e => {
       if (!this.userMarker) return;
       const heading = e.alpha ?? 0;
       const el = this.userMarker.getElement();
@@ -178,7 +178,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
   //Add centroid markers to the map
   private addCentroidsToMap(features: PlaceFeature[]): void {
     
-    features.forEach((feature: PlaceFeature, index: number) => {
+    for (const [index, feature] of features.entries()) {
       const properties = feature.properties;
       const centroid = properties?.centroid;
 
@@ -214,7 +214,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
       } else {
         console.warn(`Feature ${index + 1} no tiene coordenadas válidas de centroid`);
       }
-    });
+    }
   }
 
   ngOnDestroy(): void {

--- a/campusmap-client/src/app/modules/map/pages/map/map.html
+++ b/campusmap-client/src/app/modules/map/pages/map/map.html
@@ -1,6 +1,18 @@
 <!-- Component that renders the map -->
-<app-map-load></app-map-load>
+<app-map-load (placeSelected)="onPlaceSelected($event)" (mapClicked)="onMapClicked()"></app-map-load>
 <!-- Floating search bar. Allows you to write and select results -->
 <app-search-bar></app-search-bar>
 <!-- Filter controls. They show options to adjust the view or results -->
 <app-filter-controls></app-filter-controls>
+<!-- Information popup for selected place -->
+<app-information-pop-up
+  [placeName]="selectedPlace.name"
+  [placeType]="selectedPlace.type"
+  [imageUrl]="selectedPlace.imageUrl"
+  [isVisible]="selectedPlace.isVisible"
+  (visibleChange)="selectedPlace.isVisible = $event"
+  (showTransportSelector)="onShowTransportSelector()">
+</app-information-pop-up>
+<!-- Transport button selector popup -->
+<app-transport-button-selector *ngIf="isTransportSelectorVisible">
+</app-transport-button-selector>

--- a/campusmap-client/src/app/modules/map/pages/map/map.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/map.ts
@@ -1,13 +1,43 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { MapLoad } from './components/map-load/map-load';
 import { SearchBar } from './components/search-bar/search-bar';
 import { FilterControls } from './components/filter-controls/filter-controls';
+import { InformationPopUp } from './components/information-pop-up/information-pop-up';
+import { TransportButtonSelector } from './components/transport-button-selector/transport-button-selector';
 
 @Component({
   selector: 'app-map',
   standalone: true,
-  imports: [MapLoad, SearchBar, FilterControls],
+  imports: [CommonModule, MapLoad, SearchBar, FilterControls, InformationPopUp, TransportButtonSelector],
   templateUrl: './map.html',
   styleUrls: ['./map.scss']
 })
-export class Map {}
+export class Map {
+  @ViewChild(InformationPopUp) informationPopUp!: InformationPopUp;
+
+  selectedPlace = {
+    name: '',
+    type: '',
+    imageUrl: '',
+    isVisible: false
+  };
+
+  isTransportSelectorVisible = false;
+
+  onPlaceSelected(place: { name: string; type: string; imageUrl: string }): void {
+    this.selectedPlace = {
+      ...place,
+      isVisible: true
+    };
+  }
+
+  onShowTransportSelector(): void {
+    this.isTransportSelectorVisible = true;
+  }
+
+  onMapClicked(): void {
+    this.selectedPlace.isVisible = false;
+    this.isTransportSelectorVisible = false;
+  }
+}


### PR DESCRIPTION
This pull request introduces a set of changes to enable interactive selection and display of place information on the campus map. The main improvements include loading place data from the API, displaying centroids as clickable markers, and showing a dynamic information pop-up for selected places. The changes also refactor the code to use new models and enhance component communication.

**Map Data Integration and Display**
* Added new models (`Geometry`, `PlaceProperties`, `PlaceFeature`, `FeatureCollection`) in `place.model.ts` to structure place and geometry data for the map.
* Updated the API service to fetch places and buildings as GeoJSON feature collections from a configurable endpoint, and added methods to filter places by type.

**Map Interaction and Event Handling**
* Enhanced `MapLoad` to emit events when a place is selected or the map is clicked, and to load and display centroid markers for all places from the API. Clicking a marker emits place details for the pop-up. [[1]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aL1-R4) [[2]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aR14-R18) [[3]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aR52-R57) [[4]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aR160-R219)

**Information Pop-up Component Improvements**
* Refactored `InformationPopUp` to accept inputs for place details, visibility, and to emit events for closing and showing the transport selector. The template now displays dynamic data and includes a close button and transport selector trigger. [[1]](diffhunk://#diff-f5d524a4394a84a2a54585ce3ad2baa07c7a76b9899aecf1ef42fb53974bf165L1-R29) [[2]](diffhunk://#diff-9ce7e75536fefde66a35fa5d227905cfa3c76cccca149682ad91aaaf8aa85ce5R3-R54)

**Map Page Coordination**
* Updated the `map` page to coordinate between components: listens for place selection and map clicks, manages pop-up visibility, and conditionally shows the transport selector. [[1]](diffhunk://#diff-dac57b4c85db727574021f1984a222f5126d955819026e7e1bc934f84793a4e4L2-R18) [[2]](diffhunk://#diff-1d94364bf3b9da55576988edc054f051ba54aafc605406fb70c81df2b55ebdbdL1-R43)

These changes collectively provide a more interactive and user-friendly campus map experience, with clear separation of data models, API integration, and UI event handling.