### PR TITLE
Add width and height to filter icon

### DIFF
--- a/campusmap-client/src/app/modules/map/pages/map/components/filter-controls/filter-controls.html
+++ b/campusmap-client/src/app/modules/map/pages/map/components/filter-controls/filter-controls.html
@@ -12,6 +12,8 @@
       ngSrc="assets/icons/filters.svg"
       alt="Filtros"
       [title]="'Map.filters.title' | translate"
+      width="64"
+      height="64"
       class="w-full h-full" />
   </button>
 


### PR DESCRIPTION
This pull request introduces a minor UI improvement to the filter icon in the map filter controls. The change sets explicit width and height attributes for the icon, which helps ensure consistent sizing across different browsers and devices.