### PR TITLE
Improve filter and search functionality on map page

### DIFF
--- a/campusmap-client/src/app/core/services/api.ts
+++ b/campusmap-client/src/app/core/services/api.ts
@@ -7,7 +7,7 @@ import { FeatureCollection } from '../models/place.model';
   providedIn: 'root'
 })
 export class Api {
-  private readonly apiUrl = 'https://1hz14f3vx1.execute-api.us-east-1.amazonaws.com/';
+  private readonly apiUrl = 'https://1hz14f3vx1.execute-api.us-east-1.amazonaws.com';
 
   private readonly http = inject(HttpClient);
 
@@ -21,8 +21,19 @@ export class Api {
     return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/places`);
   }
 
-  //Gets places filtered by type example: 'building', 'parking'
-    getPlacesByType(typeCode: string): Observable<FeatureCollection> {
-      return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/sites/type/${typeCode}`);
-    }
+  //Gets sites filtered by type example: 'building', 'parking'
+  getPlacesByType(typeCode: string): Observable<FeatureCollection> {
+    return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/places/type/${typeCode}`);
+  }
+
+  // This searches places by text using the backend endpoint
+  searchPlaces(query: string): Observable<FeatureCollection> {
+    return this.http.get<FeatureCollection>(
+      `${this.apiUrl}/api/v1/places?search=${encodeURIComponent(query)}`
+    );
+  }
+  //Gets sites filtered by type example: 'building', 'parking'
+  getSitesByType(typeCode: string): Observable<FeatureCollection> {
+    return this.http.get<FeatureCollection>(`${this.apiUrl}/api/v1/sites/type/${typeCode}`);
+  }
 }

--- a/campusmap-client/src/app/modules/map/pages/map/components/filter-controls/filter-controls.html
+++ b/campusmap-client/src/app/modules/map/pages/map/components/filter-controls/filter-controls.html
@@ -19,10 +19,10 @@
   </button>
 
   <!-- Icon bar (dropdown) -->
-  <div class="w-screen h-full flex justify-end items-center mr-16">
+  <div class="flex justify-end items-center mr-0 w-auto h-auto">
     <!-- List of filters. Only shown when the user clicks on the icon -->
     @if (open()) {
-      <div class="grid grid-cols-2 w-65 h-full gap-4">
+      <div class="grid grid-cols-2 gap-4 bg-inherit z-2 w-[260px]">
         <!-- Button for each available filter -->
         @for (f of filters; track f.key) {
           <button

--- a/campusmap-client/src/app/modules/map/pages/map/components/filter-controls/filter-controls.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/filter-controls/filter-controls.ts
@@ -1,15 +1,9 @@
 import { CommonModule, NgOptimizedImage } from '@angular/common';
-import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal, ChangeDetectionStrategy, output } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { MapFilterService } from '../../../../../../core/services/map-filter.service';
 
-type FilterKey =
-  | 'building'
-  | 'parking'
-  | 'bathroom'
-  | 'cafeteria'
-  | 'assembly-point'
-  | 'warehouse';
+type FilterKey = 'building' | 'parking' | 'bathroom' | 'cafeteria' | 'assembly-point' | 'warehouse';
 
 const FILTER_DEFS: readonly {
   key: FilterKey;
@@ -19,8 +13,16 @@ const FILTER_DEFS: readonly {
   { key: 'building', i18nKey: 'Map.filters.buildings', src: 'assets/icons/mapPage/building.svg' },
   { key: 'parking', i18nKey: 'Map.filters.parking', src: 'assets/icons/mapPage/parking.svg' },
   { key: 'bathroom', i18nKey: 'Map.filters.bathrooms', src: 'assets/icons/mapPage/bath.svg' },
-  { key: 'cafeteria', i18nKey: 'Map.filters.cafeterias', src: 'assets/icons/mapPage/cafeteria.svg' },
-  { key: 'assembly-point', i18nKey: 'Map.filters.assemblyPoint', src: 'assets/icons/mapPage/assembly_point.svg' },
+  {
+    key: 'cafeteria',
+    i18nKey: 'Map.filters.cafeterias',
+    src: 'assets/icons/mapPage/cafeteria.svg'
+  },
+  {
+    key: 'assembly-point',
+    i18nKey: 'Map.filters.assemblyPoint',
+    src: 'assets/icons/mapPage/assembly_point.svg'
+  },
   { key: 'warehouse', i18nKey: 'Map.filters.warehouse', src: 'assets/icons/mapPage/warehouse.svg' }
 ];
 
@@ -32,6 +34,8 @@ const FILTER_DEFS: readonly {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FilterControls {
+  // Output para notificar al padre cuando se abre el filtro
+  readonly openFilter = output<void>();
   private readonly mapFilterService = inject(MapFilterService);
 
   //Checks if the filter panel is visible
@@ -42,7 +46,17 @@ export class FilterControls {
 
   // Changes the status of the panel when the user presses the main button
   toggle() {
+    const wasOpen = this.open();
     this.open.update(value => !value);
+    if (!wasOpen) {
+      // Si se va a abrir el filtro, notifica al padre
+      this.openFilter.emit();
+    }
+  }
+
+  // Permite cerrar el filtro desde el padre
+  close() {
+    this.open.set(false);
   }
 
   // Handle filter selection

--- a/campusmap-client/src/app/modules/map/pages/map/components/location-button/location-button.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/location-button/location-button.ts
@@ -12,7 +12,7 @@ import { GeolocationService } from '../../../../../../core/services/geolocation.
       (click)="onCenterLocation()"
       [attr.aria-label]="'Center on my location'"
       [attr.title]="'Center on my location'"
-      class="w-12 h-12 md:w-16 md:h-16 bg-white rounded-full shadow-[0_0_0_2px_rgba(0,0,0,0.1)] hover:bg-gray-100 flex items-center justify-center relative">
+      class="w-12 h-12 md:w-16 md:h-16 bg-white rounded-full shadow-[0_0_0_2px_rgba(0,0,0,0.1)] flex items-center justify-center relative">
       <!-- Location Icon -->
       <svg
         class="w-6 h-6 md:w-8 md:h-8"

--- a/campusmap-client/src/app/modules/map/pages/map/components/map-load/map-load.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/map-load/map-load.ts
@@ -265,7 +265,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
       return;
     }
 
-    // Si no hay filtro, mostrar buildings, parking y assembly_point juntos
+    // Si no hay filtro, mostrar buildings, parking y assembly-point juntos
     // buildings y parking
     this.api.getAllPlaces().subscribe({
       next: (data: FeatureCollection) => {
@@ -277,8 +277,8 @@ export class MapLoad implements AfterViewInit, OnDestroy {
         console.error('Error loading places:', error);
       }
     });
-    // assembly_point
-    this.api.getPlacesByType('assembly_point').subscribe({
+    // assembly-point
+    this.api.getSitesByType('assembly-point').subscribe({
       next: (data: FeatureCollection) => {
         if (data?.features && Array.isArray(data.features)) {
           this.addCentroidsToMap(data.features);
@@ -322,7 +322,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
     }
   }
 
-  //Get icon path for assembly_point from API
+  //Get icon path for assembly-point from API
   private getIconForPlace(properties: PlaceFeature['properties']): string {
     if (properties.type === 'assembly_point') {
       return 'https://1hz14f3vx1.execute-api.us-east-1.amazonaws.com/public/icons/assembly_point.svg';
@@ -420,7 +420,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
   private getFeatureCoordinates(feature: PlaceFeature): number[] | undefined {
     const properties = feature.properties;
     if (
-      (properties.type || '').toLowerCase() === 'assembly_point' &&
+      (properties.type || '').toLowerCase() === 'assembly-point' &&
       feature.geometry?.coordinates
     ) {
       return feature.geometry.coordinates as number[];
@@ -487,7 +487,7 @@ export class MapLoad implements AfterViewInit, OnDestroy {
     labelEl.style.fontSize = '16px';
     labelEl.style.fontWeight = '400';
     labelEl.style.letterSpacing = '1px';
-    if ((properties.type || '').toLowerCase() === 'assembly_point') {
+    if ((properties.type || '').toLowerCase() === 'assembly-point') {
       labelEl.style.color = '#358540';
     } else {
       labelEl.style.color = colorHex || '#0088c6';

--- a/campusmap-client/src/app/modules/map/pages/map/components/search-bar/search-bar.html
+++ b/campusmap-client/src/app/modules/map/pages/map/components/search-bar/search-bar.html
@@ -31,7 +31,7 @@
       class="w-full px-4 py-2 hover:bg-gray-100 cursor-pointer flex items-center justify-between text-base md:text-lg lg:text-xl leading-normal">
       <span>{{ place.properties.name }}</span>
       <!-- Show icon for history items -->
-      <i *ngIf="searchQuery().length < 3" class="pi pi-history text-gray-400 text-sm"></i>
+      <i *ngIf="searchQuery().length < 2" class="pi pi-history text-gray-400 text-sm"></i>
     </button>
   </div>
 

--- a/campusmap-client/src/app/modules/map/pages/map/components/search-bar/search-bar.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/components/search-bar/search-bar.ts
@@ -27,7 +27,7 @@ export class SearchBar implements OnInit {
   searchHistory = signal<PlaceFeature[]>([]);
 
   ngOnInit() {
-    // Load all places from the API
+    // Here we get all places from the API when the component loads
     this.apiService.getAllPlaces().subscribe({
       next: data => {
         this.allPlaces.set(data.features);
@@ -37,39 +37,55 @@ export class SearchBar implements OnInit {
       }
     });
 
-    // Load history from localStorage
+    // We also load the search history from localStorage
     this.loadHistory();
   }
 
   toggleList() {
+    // This just toggles the dropdown list open or closed
     this.isOpen.update(value => !value);
   }
 
+  private searchTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
+
   onInputChange(newValue: string) {
     this.searchQuery.set(newValue);
-    // If less than 3 characters, show history
-    if (newValue.length < 3) {
+    // If the query is less than 3 characters, just show the history and don't search
+    if (newValue.length < 2) {
       this.filteredPlaces.set([]);
+      if (this.searchTimeout) {
+        clearTimeout(this.searchTimeout);
+      }
       return;
     }
 
-    // Filter places by name (from 3 characters onwards)
-    const query = newValue.toLowerCase();
-    this.filteredPlaces.set(
-      this.allPlaces().filter(place => place.properties.name.toLowerCase().includes(query))
-    );
+    // Debounce: wait 300ms before searching so we don't spam the backend
+    if (this.searchTimeout) {
+      clearTimeout(this.searchTimeout);
+    }
+    this.searchTimeout = setTimeout(() => {
+      this.apiService.searchPlaces(newValue).subscribe({
+        next: data => {
+          this.filteredPlaces.set(data.features);
+        },
+        error: error => {
+          console.error('Error searching places:', error);
+          this.filteredPlaces.set([]);
+        }
+      });
+    }, 300);
   }
 
   onFocus() {
     this.isOpen.set(true);
-    // If no active search, show only history
-    if (this.searchQuery().length < 3) {
+    // If there is no active search, just show the history
+    if (this.searchQuery().length < 2) {
       this.filteredPlaces.set([]);
     }
   }
 
   onBlur() {
-    // Delay to allow clicking on an element
+    // We delay closing so the user can click on a result
     setTimeout(() => {
       this.isOpen.set(false);
     }, 200);
@@ -79,14 +95,15 @@ export class SearchBar implements OnInit {
     this.searchQuery.set(place.properties.name);
     this.isOpen.set(false);
 
-    // Save to history
+    // Add the selected place to the history
     this.addToHistory(place);
 
-    // Emit event with selected place
+    // Emit the event with the selected place
     this.locationSelected.emit(place);
   }
 
   private loadHistory() {
+    // This loads the search history from localStorage
     try {
       const historyJson = localStorage.getItem(HISTORY_KEY);
       if (historyJson) {
@@ -100,26 +117,26 @@ export class SearchBar implements OnInit {
 
   private addToHistory(place: PlaceFeature) {
     const currentHistory = this.searchHistory();
-    // Check if the place is already in history
+    // See if the place is already in the history
     const existingIndex = currentHistory.findIndex(item => item.id === place.id);
 
     let newHistory = [...currentHistory];
-    // If it exists, move it to the beginning
+    // If it is, move it to the front
     if (existingIndex > -1) {
       newHistory.splice(existingIndex, 1);
     }
 
-    // Add to the beginning
+    // Add the new place to the front
     newHistory.unshift(place);
 
-    // Keep only the last MAX_HISTORY_ITEMS
+    // Only keep the last MAX_HISTORY_ITEMS
     if (newHistory.length > MAX_HISTORY_ITEMS) {
       newHistory = newHistory.slice(0, MAX_HISTORY_ITEMS);
     }
 
     this.searchHistory.set(newHistory);
 
-    // Save to localStorage
+    // Save the updated history to localStorage
     try {
       localStorage.setItem(HISTORY_KEY, JSON.stringify(newHistory));
     } catch (error) {
@@ -128,11 +145,11 @@ export class SearchBar implements OnInit {
   }
 
   get displayedItems(): PlaceFeature[] {
-    // If active search (3+ characters), show filtered results
+    // If there is an active search (3+ characters), show the filtered results
     if (this.searchQuery().length >= 3) {
       return this.filteredPlaces();
     }
-    // Otherwise, show history
+    // Otherwise, just show the history
     return this.searchHistory();
   }
 }

--- a/campusmap-client/src/app/modules/map/pages/map/components/sos-button/sos-button.html
+++ b/campusmap-client/src/app/modules/map/pages/map/components/sos-button/sos-button.html
@@ -1,4 +1,4 @@
-<div class="absolute bottom-40 right-4 md:right-8 z-2 flex flex-col items-end select-none">
+<div class="absolute bottom-40 right-4 md:right-8 z-1 flex flex-col items-end select-none">
   <button
     type="button"
     class="w-10 h-10 md:w-16 md:h-16 bg-red-600 rounded-full shadow-[0_0_0_2px_rgba(0,0,0,0.1)] hover:bg-red-700">

--- a/campusmap-client/src/app/modules/map/pages/map/map.html
+++ b/campusmap-client/src/app/modules/map/pages/map/map.html
@@ -5,12 +5,12 @@
 <!-- Floating search bar. Allows you to write and select results -->
 <app-search-bar (locationSelected)="onLocationSelected($event)"></app-search-bar>
 <!-- Filter controls. They show options to adjust the view or results -->
-<app-filter-controls></app-filter-controls>
+<app-filter-controls (openFilter)="onOpenFilter()"></app-filter-controls>
 <!-- SOS button. In case of emergency, go to the nearest meeting point -->
 <app-sos-button></app-sos-button>
 <!-- Location button. Center map on user location -->
 <div
-  class="absolute top-54 md:top-59 right-4 md:right-8 z-2 flex flex-col items-end select-none mt-20">
+  class="absolute top-54 md:top-59 right-4 md:right-8 z-1 flex flex-col items-end select-none mt-20">
   <app-location-button (centerOnLocation)="onCenterOnUserLocation()"></app-location-button>
 </div>
 <!-- Popup for buildings -->

--- a/campusmap-client/src/app/modules/map/pages/map/map.ts
+++ b/campusmap-client/src/app/modules/map/pages/map/map.ts
@@ -28,8 +28,17 @@ import { GeolocationService } from '../../../../core/services/geolocation.servic
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class Map {
+  // Cierra el popup al abrir el filtro
+  onOpenFilter(): void {
+    this.selectedPlace.update(place => ({
+      ...place,
+      isVisible: false
+    }));
+    this.isTransportSelectorVisible.set(false);
+  }
   mapLoad = viewChild.required<MapLoad>(MapLoad);
   informationPopUp = viewChild.required<InformationPopUp>(InformationPopUp);
+  filterControls = viewChild.required<FilterControls>(FilterControls);
 
   private readonly geolocationService = inject(GeolocationService);
 
@@ -89,6 +98,8 @@ export class Map {
       isVisible: false
     }));
     this.isTransportSelectorVisible.set(false);
+    // Cierra el filtro si está abierto
+    this.filterControls()?.close();
   }
 
   onLocationSelected(place: PlaceFeature): void {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the campus map client, focusing on enhancing search functionality, filter controls, and consistency in naming conventions for place types. The changes improve user experience by making search more responsive, refining filter interactions, and ensuring consistent data handling for map features.

**Search and filter enhancements:**

* Added a debounced backend-powered search to the `SearchBar` component, replacing the previous client-side filtering. The search now triggers after 300ms and only for queries with 2 or more characters, improving performance and accuracy. [[1]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L40-R88) [[2]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L131-R152)
* Updated the filter controls to emit an event when opened, allowing the parent map component to respond (e.g., closing popups). Also added a method to programmatically close the filter panel from the parent. [[1]](diffhunk://#diff-5f272ec17aee1d0919959388e863f6cfdf95eb745a3ec5a9afc3c2e9aff17188R37-R38) [[2]](diffhunk://#diff-5f272ec17aee1d0919959388e863f6cfdf95eb745a3ec5a9afc3c2e9aff17188R49-R59) [[3]](diffhunk://#diff-dac57b4c85db727574021f1984a222f5126d955819026e7e1bc934f84793a4e4L8-R13) [[4]](diffhunk://#diff-1d94364bf3b9da55576988edc054f051ba54aafc605406fb70c81df2b55ebdbdR31-R41) [[5]](diffhunk://#diff-1d94364bf3b9da55576988edc054f051ba54aafc605406fb70c81df2b55ebdbdR101-R102)

**API and data consistency:**

* Introduced new API methods in `api.ts` for searching places and retrieving sites by type, and standardized type naming from `assembly_point` to `assembly-point` throughout the codebase for consistency with backend data. [[1]](diffhunk://#diff-0dc78ba69d20a13468366cf3566899490dbf317b7287a083d4102b88e18ee47dL24-R36) [[2]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aL268-R268) [[3]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aL280-R281) [[4]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aL325-R325) [[5]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aL423-R423) [[6]](diffhunk://#diff-084c521af475c67e05693b57b0fa32cdb97842ae097817f485a2d4bdcd2b4c2aL490-R490)

**UI and style adjustments:**

* Improved layout and z-index stacking for filter controls, SOS button, and location button to ensure proper visibility and interaction. [[1]](diffhunk://#diff-7667e7a56b73e96e9b9b80738713a9ee3ed89d11553ff80df313dde3868f5d7fL22-R25) [[2]](diffhunk://#diff-c83ebc4a5ea69d5674e492848ab0258fc4e447456462d7f771f0d3b492ae6795L15-R15) [[3]](diffhunk://#diff-252e51979dd13d9bf23c801f65245bba69192e0ca6f32a1f5bef4ce34f3072c3L1-R1) [[4]](diffhunk://#diff-dac57b4c85db727574021f1984a222f5126d955819026e7e1bc934f84793a4e4L8-R13)
* Updated the search bar to show history for queries shorter than 2 characters, making the UI more intuitive. [[1]](diffhunk://#diff-b9bd4ff224408b9ea82bcfe5daf3256a4089feea220a322e97f8ccac65a042e0L34-R34) [[2]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L40-R88) [[3]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L131-R152)

**Code cleanup and documentation:**

* Enhanced code comments and documentation in the `SearchBar` and filter controls, making the code easier to understand for future maintenance. [[1]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L30-R30) [[2]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L82-R106) [[3]](diffhunk://#diff-98ea79d3aabc11d5e8a9a516e86b6e59b5f39618e09236bfd35744c3affcd4d9L103-R139) [[4]](diffhunk://#diff-5f272ec17aee1d0919959388e863f6cfdf95eb745a3ec5a9afc3c2e9aff17188L22-R25)

**Minor fixes:**

* Removed unnecessary hover effect from the location button and adjusted API URL formatting. [[1]](diffhunk://#diff-c83ebc4a5ea69d5674e492848ab0258fc4e447456462d7f771f0d3b492ae6795L15-R15) [[2]](diffhunk://#diff-0dc78ba69d20a13468366cf3566899490dbf317b7287a083d4102b88e18ee47dL10-R10)