### PR TITLE
Update MapLoad tests to use PlaceProperties type

### DIFF
--- a/campusmap-client/src/app/pages/map/components/map-load/map-load.spec.ts
+++ b/campusmap-client/src/app/pages/map/components/map-load/map-load.spec.ts
@@ -4,6 +4,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { MapLoad } from './map-load';
 import { Api } from '@shared/services/api';
+import { PlaceProperties } from '@shared/types/place.model';
 
 describe('MapLoad', () => {
   let component: MapLoad;
@@ -26,14 +27,17 @@ describe('MapLoad', () => {
 
   it('emits building popup for cafeteria type', () => {
     const spy = jest.spyOn(component.placeSelected, 'emit');
-    const props: any = {
+    const props: PlaceProperties = {
       id: 25,
       name: 'Cafeteria Central',
       type: 'cafeteria',
       imageUrl: '',
-      images: []
+      images: [],
+      centroid: { type: 'Point', coordinates: [0, 0] }
     };
-    (component as any).handleMarkerClick(props);
+    (
+      component as unknown as { handleMarkerClick: (properties: PlaceProperties) => void }
+    ).handleMarkerClick(props);
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ id: 25, name: 'Cafeteria Central', type: 'building' })
     );
@@ -41,13 +45,16 @@ describe('MapLoad', () => {
 
   it('emits parking popup for parking type', () => {
     const spy = jest.spyOn(component.placeSelected, 'emit');
-    const props: any = {
+    const props: PlaceProperties = {
       id: 99,
       name: 'Parking A',
       type: 'parking',
-      imageUrl: ''
+      imageUrl: '',
+      centroid: { type: 'Point', coordinates: [0, 0] }
     };
-    (component as any).handleMarkerClick(props);
+    (
+      component as unknown as { handleMarkerClick: (properties: PlaceProperties) => void }
+    ).handleMarkerClick(props);
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ id: 99, name: 'Parking A', type: 'parking' })
     );


### PR DESCRIPTION
This pull request improves the type safety and accuracy of the `MapLoad` component unit tests by updating the test mocks to use the `PlaceProperties` type and by providing all required properties. It also updates the way the `handleMarkerClick` method is invoked to ensure proper type compatibility.

**Test improvements:**

* Updated test mocks in `map-load.spec.ts` to use the `PlaceProperties` type instead of `any`, and included the required `centroid` property.
* Changed the invocation of `handleMarkerClick` in tests to use a type-safe cast instead of `as any`, improving type correctness.
* Added the missing import for `PlaceProperties` from `@shared/types/place.model`.