### PR TITLE
Update SOS button and info pop-up image handling

### DIFF
--- a/campusmap-client/public/assets/i18n/en.json
+++ b/campusmap-client/public/assets/i18n/en.json
@@ -37,6 +37,7 @@
     }
   },
   "Transport": {
+    "messageSelector": "Select your mode of transport",
     "car": "Car",
     "walk": "Walk",
     "selectionRequired": "Selection is required.",

--- a/campusmap-client/public/assets/i18n/en.json
+++ b/campusmap-client/public/assets/i18n/en.json
@@ -39,7 +39,6 @@
   "Transport": {
     "car": "Car",
     "walk": "Walk",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id faucibus libero.",
     "selectionRequired": "Selection is required.",
     "start": "Start",
     "arrowAlt": "Start arrow"

--- a/campusmap-client/public/assets/i18n/es.json
+++ b/campusmap-client/public/assets/i18n/es.json
@@ -39,7 +39,6 @@
   "Transport": {
     "car": "Carro",
     "walk": "Caminar",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id faucibus libero.",
     "selectionRequired": "La selección es requerida.",
     "start": "Iniciar",
     "arrowAlt": "Flecha de inicio"

--- a/campusmap-client/public/assets/i18n/es.json
+++ b/campusmap-client/public/assets/i18n/es.json
@@ -37,6 +37,7 @@
     }
   },
   "Transport": {
+    "messageSelector": "Selecciona tu medio de transporte",
     "car": "Carro",
     "walk": "Caminar",
     "selectionRequired": "La selección es requerida.",

--- a/campusmap-client/public/assets/icons/sos.svg
+++ b/campusmap-client/public/assets/icons/sos.svg
@@ -1,48 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg
-   xml:space="preserve"
-   id="svg1"
-   width="38.426"
-   height="38.427"
-   viewBox="0 0 10.167 10.167"
-   version="1.1"
-   sodipodi:docname="sos.svg"
-   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><defs
-     id="defs1" /><sodipodi:namedview
-     id="namedview1"
-     pagecolor="#505050"
-     bordercolor="#eeeeee"
-     borderopacity="1"
-     inkscape:showpageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#505050"
-     inkscape:zoom="3.5560515"
-     inkscape:cx="27.41805"
-     inkscape:cy="62.569397"
-     inkscape:window-width="1920"
-     inkscape:window-height="991"
-     inkscape:window-x="2391"
-     inkscape:window-y="-9"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg1" /><g
-     id="layer1"
-     style="fill:#173f6f;fill-opacity:1;stroke:none;stroke-width:0.399997;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-     transform="matrix(0.96064,0,0,0.96067,-89.459089,-141.44297)"><g
-       id="g1"
-       style="fill:#173f6f;fill-opacity:1;stroke:none;stroke-width:6.86602;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-       transform="matrix(0.05826,0,0,0.05826,92.288,144.09)"><circle
-         id="path1"
-         cx="105.188"
-         cy="144.787"
-         r="90.832001"
-         style="display:inline;fill:#173f6f;fill-opacity:1;stroke:none;stroke-width:6.86602;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal" /></g></g><path
-     style="fill:#ffffff;stroke-width:0.34483"
-     d="M 3.0201559,7.6069441 C 2.837689,7.5661779 2.6908073,7.4781284 2.5748252,7.3399857 2.5156654,7.2695227 2.4374528,7.1167992 2.4149909,7.0278824 2.3763862,6.8750637 2.3856666,6.7041322 2.4401807,6.563913 2.4698947,6.4874796 4.3472192,3.0262578 4.4241267,2.9061109 4.653189,2.5482625 5.1288095,2.4417997 5.50088,2.6650903 c 0.077535,0.046531 0.1877854,0.1563338 0.2420038,0.2410206 0.07717,0.1205375 1.954416,3.5815118 1.9840059,3.6578021 0.054454,0.1403992 0.063705,0.3112352 0.025121,0.4639694 C 7.7295483,7.1167992 7.651336,7.2695227 7.5921764,7.3399857 7.4919787,7.4593274 7.3491725,7.5518737 7.194218,7.5978847 7.1346766,7.615564 7.0148523,7.6167332 5.1045552,7.6182604 3.5355108,7.6195028 3.0649857,7.6169514 3.0201559,7.6069432 Z M 5.2150914,6.9603212 C 5.4600138,6.844267 5.4572931,6.5053415 5.2105286,6.3919293 5.0145552,6.3018604 4.7875311,6.4385067 4.7706338,6.656703 c -0.013783,0.1779719 0.1321478,0.3335478 0.3128667,0.3335478 0.053362,0 0.082334,-0.00659 0.1315909,-0.029931 z m 0,-0.9474542 C 5.2929904,5.975955 5.3476345,5.91698 5.3772315,5.8378755 c 0.022479,-0.060082 0.022555,-0.063545 0.019693,-0.9146177 l -0.00287,-0.8543075 -0.024,-0.048713 c -0.1190909,-0.2417177 -0.4540176,-0.2417177 -0.5731085,0 l -0.024,0.048713 -0.00287,0.8543074 c -0.00287,0.8510732 -0.0028,0.8545356 0.019693,0.9146177 0.046312,0.123781 0.1626177,0.2049211 0.2937307,0.2049211 0.053362,0 0.082335,-0.00659 0.1315909,-0.029931 z"
-     id="path22" /></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" id="svg1" width="38.426" height="38.427" viewBox="0 0 10.167 10.167"><g id="layer1" style="fill:#fc0;fill-opacity:1;stroke:none;stroke-width:.399997;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal" transform="matrix(.96064 0 0 .96067 -89.46 -141.443)"><g id="g1" style="fill:#fc0;fill-opacity:1;stroke:none;stroke-width:6.86602;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal" transform="translate(92.288 144.09)scale(.05826)"><circle id="path1" cx="105.188" cy="144.787" r="90.832" style="display:inline;fill:#fc0;fill-opacity:1;stroke:none;stroke-width:6.86602;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"/></g></g><path id="path2" d="M3.175 7.442a.7.7 0 0 1-.365-.175.71.71 0 0 1-.242-.549c0-.126.022-.22.08-.336A409 409 0 0 1 4.48 3.025a.744.744 0 0 1 .868-.266.8.8 0 0 1 .352.29c.06.093 1.813 3.321 1.844 3.394.038.09.061.232.054.325a.7.7 0 0 1-.08.28.7.7 0 0 1-.325.33c-.163.08.03.074-2.068.076-1.499 0-1.887-.001-1.95-.012M7.05 7.12q.18-.09.236-.272a.44.44 0 0 0-.004-.268c-.023-.067-1.81-3.354-1.856-3.415a.452.452 0 0 0-.7.012 219 219 0 0 0-1.85 3.403.45.45 0 0 0 .298.568c.031.01.42.012 1.92.01l1.882-.001zm-2.064-.272a.29.29 0 0 1-.115-.478.27.27 0 0 1 .166-.085c.078-.014.14 0 .206.045.117.08.16.214.111.345a.29.29 0 0 1-.368.173m0-.886a.29.29 0 0 1-.192-.224c-.008-.042-.01-.282-.008-.827l.003-.768.023-.05a.33.33 0 0 1 .13-.142.35.35 0 0 1 .203-.03c.059.013.14.068.174.117.058.083.056.053.056.908 0 .778 0 .787-.021.843a.29.29 0 0 1-.368.173" style="fill:#000;fill-opacity:1;stroke-width:.198626"/></svg>

--- a/campusmap-client/src/app/modules/map/pages/map/components/sos-button/sos-button.html
+++ b/campusmap-client/src/app/modules/map/pages/map/components/sos-button/sos-button.html
@@ -1,7 +1,7 @@
 <div class="absolute bottom-40 right-4 md:right-8 z-1 flex flex-col items-end select-none">
   <button
     type="button"
-    class="w-10 h-10 md:w-16 md:h-16 bg-red-600 rounded-full shadow-[0_0_0_2px_rgba(0,0,0,0.1)] hover:bg-red-700"
+    class="w-10 h-10 md:w-16 md:h-16 rounded-full shadow-[0_0_0_2px_rgba(0,0,0,0.1)]"
     (click)="onClick()">
     <img src="assets/icons/sos.svg" alt="Botón de SOS" class="w-full h-full" />
   </button>

--- a/campusmap-client/src/app/pages/home/components/home-message/home-message.html
+++ b/campusmap-client/src/app/pages/home/components/home-message/home-message.html
@@ -15,5 +15,10 @@
 <!-- Visitors Wifi -->
 <div class="flex flex-col h-1/2 items-center justify-center lg:justify-center">
   <!-- Logo Network -->
-  <img src="assets/images/logo_network.svg" alt="" class="w-40 md:w-45 lg:w-50" />
+  <img
+    src="assets/images/logo_network.svg"
+    alt=""
+    class="w-30 md:w-45 lg:w-50"
+    width="200"
+    height="200" />
 </div>

--- a/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.html
+++ b/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.html
@@ -5,43 +5,41 @@
     <div class="flex flex-col h-full">
       <!-- Point of interest titles -->
       <div class="flex flex-col">
-        <p
-          class="font-semibold text-xl md:text-3xl lg:text-2xl leading-normal md:leading-tight lg:leading-normal">
+        <p class="font-semibold text-black text-xl md:text-3xl lg:text-2xl">
           {{ 'Buildings.' + placeName() | translate: {} : placeName() }}
         </p>
-        <p
-          class="text-gray-600 text-xl md:text-3xl lg:text-2xl leading-normal md:leading-tight lg:leading-normal">
+        <p class="text-gray-600 text-xl md:text-3xl lg:text-2xl">
           {{ 'InformationPopUp.' + placeType() | translate }}
         </p>
       </div>
       <!-- Related images section -->
       <div class="flex w-full justify-center gap-4 md:gap-8 my-4 md:my-8 lg:my-4 px-2 md:px-4">
-        @if (imageUrl()) {
+        @if (imageUrl() && imageLoaded() && !showFallback()) {
           <img
             [src]="imageUrl()"
             [alt]="placeName()"
-            title="placeName()"
+            [title]="placeName()"
+            (error)="showFallback.set(true)"
             class="w-full h-40 md:h-64 lg:h-72 rounded-lg object-cover" />
-        }
-        @if (!imageUrl() && images().length) {
+        } @else if (images().length && !showFallback()) {
           @for (img of images().slice(0, 2); track img.id) {
             <img
               [src]="img.img"
               [alt]="placeName() || ('InformationPopUp.alt' | translate)"
-              title="placeName() || ('InformationPopUp.alt' | translate)"
+              [title]="placeName() || ('InformationPopUp.alt' | translate)"
+              (error)="showFallback.set(true)"
               class="w-1/2 h-40 md:h-64 lg:h-72 rounded-lg object-cover" />
           }
-        }
-        @if (!imageUrl() && !images().length) {
+        } @else {
           <img
             src="assets/images/rs.webp"
             [alt]="'InformationPopUp.Alt' | translate"
-            title="'InformationPopUp.Alt' | translate"
+            [title]="'InformationPopUp.Alt' | translate"
             class="w-1/2 h-40 md:h-64 lg:h-72 rounded-lg object-cover" />
           <img
             src="assets/images/sostenibilidad.webp"
             [alt]="'InformationPopUp.Alt' | translate"
-            title="'InformationPopUp.Alt' | translate"
+            [title]="'InformationPopUp.Alt' | translate"
             class="w-1/2 h-40 md:h-64 lg:h-72 rounded-lg object-cover" />
         }
       </div>

--- a/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.ts
+++ b/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.ts
@@ -29,6 +29,13 @@ export class InformationPopUp {
         this.showFallback.set(false);
       }
     });
+    
+    effect(() => {
+      if (this.placeName()) {
+        this.imageLoaded.set(true);
+        this.showFallback.set(false);
+      }
+    });
   }
 
   close(): void {

--- a/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.ts
+++ b/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output, signal, ChangeDetectionStrategy, effect } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonModule } from '@angular/common';
@@ -14,10 +14,22 @@ export class InformationPopUp {
   placeName = input('');
   placeType = input('');
   imageUrl = input('');
-  images = input<{ id: number; img: string }[]>([]); // Input para el array de imágenes con id y url
+  images = input<{ id: number; img: string }[]>([]);
   isVisible = input(false);
   visibleChange = output<boolean>();
   showTransportSelector = output<void>();
+
+  imageLoaded = signal(true);
+  showFallback = signal(false);
+
+  constructor() {
+    effect(() => {
+      if (this.imageUrl()) {
+        this.imageLoaded.set(true);
+        this.showFallback.set(false);
+      }
+    });
+  }
 
   close(): void {
     this.visibleChange.emit(false);

--- a/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.ts
+++ b/campusmap-client/src/app/pages/map/components/information-pop-up/information-pop-up.ts
@@ -29,7 +29,7 @@ export class InformationPopUp {
         this.showFallback.set(false);
       }
     });
-    
+
     effect(() => {
       if (this.placeName()) {
         this.imageLoaded.set(true);

--- a/campusmap-client/src/app/pages/map/components/transport-button-selector/transport-button-selector.html
+++ b/campusmap-client/src/app/pages/map/components/transport-button-selector/transport-button-selector.html
@@ -59,10 +59,6 @@
             </ng-template>
           </p-selectbutton>
         </div>
-        <!-- Lower descriptive text -->
-        <p class="overflow-hidden text-clip font-medium py-4">
-          {{ 'Transport.description' | translate }}
-        </p>
 
         <!-- Error message. Only visible if there is interaction or sending -->
         @if (model.invalid && (model.touched || exampleForm.submitted)) {

--- a/campusmap-client/src/app/pages/map/components/transport-button-selector/transport-button-selector.html
+++ b/campusmap-client/src/app/pages/map/components/transport-button-selector/transport-button-selector.html
@@ -11,10 +11,17 @@
       class="flex justify-center flex-col">
       <!-- Main group of the form -->
       <div class="flex flex-col">
+        <!-- Message Transport Selector -->
+        <div class="mb-4 text-2xl font-semibold text-center">
+          <p>
+            {{ 'Transport.messageSelector' | translate }}
+          </p>
+        </div>
+
         <!-- Transport mode selector. Use ngModel to bind the value -->
         <div class="flex w-full justify-center">
           <p-selectbutton
-            class="h-12 md:h-15 lg:h-12 w-full max-w-md rounded justify-center rounded-lg shadow-[4px_4px_5px_rgba(0,0,0,0.3)]"
+            class="h-12 md:h-15 lg:h-12 w-70 mb-8 justify-center"
             #model="ngModel"
             [ngModel]="value()"
             (ngModelChange)="value.set($event)"

--- a/campusmap-client/src/app/pages/map/components/transport-button-selector/transport-button-selector.scss
+++ b/campusmap-client/src/app/pages/map/components/transport-button-selector/transport-button-selector.scss
@@ -10,7 +10,7 @@
   background: var(--background-blue);
   color: var(--color-primary-white);
   height: auto;
-  border-radius: 0.5rem;
+  border-radius: calc(infinity * 1px);
 }
 
 :host ::ng-deep .p-togglebutton {
@@ -21,7 +21,7 @@
 
 :host ::ng-deep .p-selectbutton {
   background: var(--color-primary-blue);
-  border-radius: 0.5rem;
+  border-radius: calc(infinity * 1px);
 }
 
 :host ::ng-deep .p-togglebutton:not(:disabled):not(.p-togglebutton-checked):hover {


### PR DESCRIPTION
Changed SOS button to remove red background and updated the SOS icon to use a yellow color. Improved image loading and fallback logic in the information pop-up component, including new signals for image state. Removed unused transport description from translations and UI, and adjusted home message image sizing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves resiliency and clarity of UI elements and translations.
> 
> - Information pop-up: adds `imageLoaded`/`showFallback` signals with an `effect` to reset on `imageUrl` changes; template now handles errors via `(error)` to switch to gallery or static fallback images; minor attribute fixes (`[title]`) and style tweaks
> - SOS button/icon: removes red background from button and replaces `sos.svg` with a simplified yellow icon
> - Transport selector: removes unused description text and deletes `Transport.description` from `en.json`/`es.json`
> - Home message: adjusts network logo size (`w-30`) and sets explicit `width`/`height` attributes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d54774776910809c23c96d18dede06968c376174. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->