### PR TITLE
Remove priority attribute from logo image

### DIFF
--- a/campusmap-client/src/app/pages/map/map.html
+++ b/campusmap-client/src/app/pages/map/map.html
@@ -50,11 +50,5 @@
 
 <!-- Brand watermark reflecting the selected language -->
 <div class="absolute bottom-4 left-4 z-1">
-  <img
-    [ngSrc]="logoPath()"
-    [alt]="logoAlt()"
-    title="alliance logo"
-    width="80"
-    height="20"
-    priority />
+  <img [ngSrc]="logoPath()" [alt]="logoAlt()" title="alliance logo" width="80" height="20" />
 </div>


### PR DESCRIPTION
The 'priority' attribute was removed from the logo image in map.html.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - In `map.html`, removed the `priority` attribute from the brand watermark `<img>` and collapsed its attributes to a single line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69837d9e1c935e51199b5e1f5d81f24d9a9df25c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->