### PR TITLE
chore: set .env file on modules

### DIFF
--- a/campusmap-server/src/app.module.ts
+++ b/campusmap-server/src/app.module.ts
@@ -41,7 +41,7 @@ import { RoutingModule } from './modules/routing/routing.module';
     }),
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: ['.env.local', '.env'],
+      envFilePath: ['.env'],
     }),
     TypeOrmModule.forRootAsync({
       useFactory: () => buildTypeOrmOptions(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows environment configuration to a single file.
> 
> - Updates `ConfigModule.forRoot` in `app.module.ts` to load env vars only from `.env` (removes `.env.local` from `envFilePath`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2c91f5017bb9ef60bea48394317b0eaf6ca841. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->